### PR TITLE
Update for reference writing, parsed filename output

### DIFF
--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -353,7 +353,7 @@ class Translator(object):
             self.data['authors'] = new_authors
                    
 
-    def translate(self, data=None, publisher=None, bibstem=None, parsedfile=None):
+    def translate(self, data=None, publisher=None, bibstem=None, parsedfile=False):
         if data:
             self.data = data
         if not self.data:

--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -193,7 +193,8 @@ class Translator(object):
             odate = None
             
             for od in otherdate:
-                if od.get('otherDateType', None) == 'Available':
+                odtype = od.get('otherDateType', None)
+                if odtype in ['Available', 'Issued']:
                     odate = od.get('otherDateValue', None)
             if odate:
                 otherdate = odate
@@ -296,6 +297,8 @@ class Translator(object):
                     pubstring = pubstring + ', ' + pagecount + ' pp.'
             if pubstring:
                 self.output['publication'] = pubstring
+            if publisher == 'Zenodo':
+                self.output['source'] = publisher
 
     def _get_bibcode(self, bibstem=None):
         try:

--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -1,5 +1,4 @@
 from adsmanparse.exceptions import *
-#from pyingest.config.config import *
 from adsenrich.bibcodes import BibcodeGenerator
 from bs4 import BeautifulSoup
 import re
@@ -223,7 +222,7 @@ class Translator(object):
             self.output['pubdate'] = "%s/%s" % (m,y)
 
 
-    def _get_properties(self):
+    def _get_properties(self, parsedfile):
         props = {}
         persistentids = self.data.get('persistentIDs', None)
         if persistentids:
@@ -234,6 +233,11 @@ class Translator(object):
         openaccess = self.data.get('openAccess', {}).get('open', False)
         if openaccess:
             props['OPEN'] = 1
+
+        if parsedfile:
+            parsedFileName = self.data.get('recordData', {}).get('loadLocation', None)
+            if parsedFileName:
+                props['FILE'] = parsedFileName
             
         if props:
             self.output['properties'] = props
@@ -349,7 +353,7 @@ class Translator(object):
             self.data['authors'] = new_authors
                    
 
-    def translate(self, data=None, publisher=None, bibstem=None):
+    def translate(self, data=None, publisher=None, bibstem=None, parsedfile=None):
         if data:
             self.data = data
         if not self.data:
@@ -363,6 +367,6 @@ class Translator(object):
             self._get_auths_affils()
             self._get_date()
             self._get_references()
-            self._get_properties()
+            self._get_properties(parsedfile)
             self._get_publication()
             self._get_bibcode(bibstem=bibstem)

--- a/run.py
+++ b/run.py
@@ -184,10 +184,17 @@ def main():
         if parser:
             try:
                 parser.__init__()
+                parsedrecord = None
                 if ptype == 'nlm':
-                    ingestDocList.append(parser.parse(pdata, bsparser='lxml-xml'))
+                    parsedrecord = parser.parse(pdata, bsparser='lxml-xml')
                 else:
-                    ingestDocList.append(parser.parse(pdata))
+                    parsedrecord = parser.parse(pdata)
+                if parsedrecord:
+                    if filename:
+                        parsedrecord.setdefault("recordData", {}).setdefault("loadLocation", filename)
+                    ingestDocList.append(parsedrecord)
+                else:
+                    raise Exception("Null body returned by parser!")
             except Exception as err:
                 logger.warning("Error parsing record (%s): %s" % (filename,err))
         else:

--- a/run.py
+++ b/run.py
@@ -102,7 +102,7 @@ def get_args():
                         '--parsedfile',
                         dest='parsedfile',
                         action='store_true',
-                        default=None,
+                        default=False,
                         help='Output parsed filename in properties tag')
 
 
@@ -198,7 +198,8 @@ def main():
                     parsedrecord = parser.parse(pdata)
                 if parsedrecord:
                     if filename:
-                        parsedrecord.setdefault("recordData", {}).setdefault("loadLocation", filename)
+                        if not parsedrecord.get("recordData", {}).get("loadLocation", None):
+                            parsedrecord["recordData"]["loadLocation"] = filename
                     ingestDocList.append(parsedrecord)
                 else:
                     raise Exception("Null body returned by parser!")

--- a/run.py
+++ b/run.py
@@ -101,7 +101,7 @@ def get_args():
     parser.add_argument('-z',
                         '--parsedfile',
                         dest='parsedfile',
-                        action='store',
+                        action='store_true',
                         default=None,
                         help='Output parsed filename in properties tag')
 

--- a/run.py
+++ b/run.py
@@ -98,6 +98,13 @@ def get_args():
                         default=None,
                         help='Origin/publisher of record/reference data')
 
+    parser.add_argument('-z',
+                        '--parsedfile',
+                        dest='parsedfile',
+                        action='store',
+                        default=None,
+                        help='Output parsed filename in properties tag')
+
 
     args = parser.parse_args()
     return args
@@ -107,7 +114,7 @@ def create_tagged(rec=None, args=None):
     try:
         xlator = translator.Translator()
         seri = classic_serializer.ClassicSerializer()
-        xlator.translate(data=rec, bibstem=args.bibstem)
+        xlator.translate(data=rec, bibstem=args.bibstem, parsedfile=args.parsedfile)
         output = seri.output(xlator.output)
         return output
     except Exception as err:


### PR DESCRIPTION
- enables writing reference files (use `-w -r /reference/base/path -s pubabbrev`)
- enables output of the parsed filename to the tagged record properties (%I)

Examples:

# Parse one delivery of IOP
```
python run.py -p "/incoming/data/IOPP/**/*.xml" -a 365 -t jats -w -r "/home/data/references/sources/" -s iop -f iop_records.tag -z
```

# Parse one doi, including references
```
python run.py -d 10.3847/1538-4357/ad0047 -w -s crossref -r "/home/data/references/sources/" -f my_single_doi_record.tag
```