### PR TITLE
adds copyright to tagged output

### DIFF
--- a/adsmanparse/classic_serializer.py
+++ b/adsmanparse/classic_serializer.py
@@ -29,6 +29,7 @@ class ClassicSerializer(object):
         data = re.sub(r"&[rl]squo;", "\'", data)
         data = re.sub(r"&[rl]dquo;", "\"", data)
         data = re.sub(r"&nbsp;", " ", data)
+        data = re.sub(r"&zwnj;", " ", data)
         return data
 
     def __init__(self, **kwargs):
@@ -43,6 +44,7 @@ class ClassicSerializer(object):
             ('language', {'tag': 'M'}),
             ('comments', {'tag': 'X', 'join': '; '}),
             ('source', {'tag': 'G'}),
+            ('copyright', {'tag': 'C'}),
             ('uatkeys', {'tag': 'U', 'join': ', '}),
             ('keywords', {'tag': 'K', 'join': ', '}),
             ('subjectcategory', {'tag': 'Q', 'join': '; '}),

--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -337,6 +337,10 @@ class Translator(object):
         except Exception as err:
             print('Couldnt make a bibcode: %s' % str(err))
 
+    def _get_copyright(self):
+        copyright_statement=self.data.get("copyright", {}).get("statement", None)
+        if copyright_statement:
+            self.output["copyright"] = copyright_statement
 
     def _special_handling(self, bibstem=None):
         # Special data handling rules on a per-bibstem basis
@@ -397,3 +401,4 @@ class Translator(object):
             self._get_properties(parsedfile)
             self._get_publication()
             self._get_bibcode(bibstem=bibstem)
+            self._get_copyright()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/adsabs/ADSIngestParser@v0.9.13
-git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.5
+git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.6
 adsputils==1.5.2
 habanero==0.7.4
 namedentities==1.9.4


### PR DESCRIPTION
 	modified:   adsmanparse/classic_serializer.py
 	modified:   adsmanparse/translator.py
 	modified:   requirements.txt

- get copyright.statement from ingest_data_model and send to classic tagger (`%C`)
- search and replace `&zwnj;` entity with space