### PR TITLE
Updater 20250121

### DIFF
--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -175,20 +175,21 @@ class Translator(object):
             affil_list = list()
             native_author_list = list()
             for a in authors:
-                # person
                 name = a.get('name', None)
+                # individual (person or collab)
                 if name:
                     # person name
                     (auth, native_auth) = self._get_name(name)
-                    # person attribs and affil
-                    aff = self._get_affil(a)
-                    if aff == 'None':
-                        aff = ''
-                    if native_auth == 'None':
-                        native_auth = ''
-                    author_list.append(auth)
-                    native_author_list.append(native_auth)
-                    affil_list.append(aff)
+                    if auth not in author_list:
+                        # person attribs and affil
+                        aff = self._get_affil(a)
+                        if aff == 'None':
+                            aff = ''
+                        if native_auth == 'None':
+                            native_auth = ''
+                        author_list.append(auth)
+                        native_author_list.append(native_auth)
+                        affil_list.append(aff)
             self.output['authors'] = author_list
             self.output['affiliations'] = affil_list
             self.output['native_authors'] = native_author_list

--- a/adsmanparse/translator.py
+++ b/adsmanparse/translator.py
@@ -320,6 +320,8 @@ class Translator(object):
         openaccess = self.data.get('openAccess', {}).get('open', False)
         if openaccess:
             props['OPEN'] = 1
+        elif "creativecommons.org" in self.data.get('openAccess', {}).get('licenseURL', ''):
+            props['OPEN'] = 1
 
         if parsedfile:
             parsedFileName = self.data.get('recordData', {}).get('loadLocation', None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/seasidesparrow/ADSIngestParser@jats_email_problem_iop.20250117
-git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.19
+git+https://github.com/adsabs/ADSIngestParser@v0.9.36
+git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.20
 adsputils==1.5.2
 habanero==0.7.4
 namedentities==1.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSIngestParser@v0.9.36
+git+https://github.com/seasidesparrow/ADSIngestParser@jats_email_problem_iop.20250117
 git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.19
 adsputils==1.5.2
 habanero==0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSIngestParser@v0.9.35
+git+https://github.com/adsabs/ADSIngestParser@v0.9.36
 git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.19
 adsputils==1.5.2
 habanero==0.7.4


### PR DESCRIPTION
Patches to address specific parsing issues
- delete multiple instances of a contributor when translating to classic format
- set attribute OPEN: 1 for cases where the license URL is of the form`creativecommons.org`
- bump IngestParser/Enrichment versions to latest releases (v0.9.36/v0.9.20)