### PR TITLE
Ref bib.20250415

### DIFF
--- a/adsmanparse/classic_serializer.py
+++ b/adsmanparse/classic_serializer.py
@@ -34,6 +34,7 @@ class ClassicSerializer(object):
 
     def __init__(self, **kwargs):
         self.AFF_LABEL = self._aff_codes_generator()
+        self.TAG_REFS = kwargs.get("tag_refs", False)
         self.FIELD_DICT = OrderedDict([
             ('bibcode', {'tag': 'R'}),
             ('title', {'tag': 'T'}),
@@ -67,6 +68,9 @@ class ClassicSerializer(object):
 
     def output(self, record):
         output_text = []
+        if self.TAG_REFS:
+            record["references"] = record["refhandler_list"]
+            del record["refhandler_list"]
         for k, v in self.FIELD_DICT.items():
             rec_field = record.get(k, None)
             if k == "affiliations" or k == "native_authors":

--- a/adsmanparse/classic_serializer.py
+++ b/adsmanparse/classic_serializer.py
@@ -54,7 +54,7 @@ class ClassicSerializer(object):
             ('page', {'tag': 'P'}),
             ('abstract', {'tag': 'B'}),
             ('properties', {'tag': 'I', 'join': '; '}),
-            ('references', {'tag': 'Z', 'join': "\n   "}),])
+            ('references', {'tag': 'Z', 'join': "\n"}),])
         pass
 
     def _format_affil_field(self, affils):
@@ -69,8 +69,9 @@ class ClassicSerializer(object):
     def output(self, record):
         output_text = []
         if self.TAG_REFS:
-            record["references"] = record["refhandler_list"]
-            del record["refhandler_list"]
+            if record.get("refhandler_list", None):
+                record["references"] = record["refhandler_list"]
+                del record["refhandler_list"]
         for k, v in self.FIELD_DICT.items():
             rec_field = record.get(k, None)
             if k == "affiliations" or k == "native_authors":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/adsabs/ADSIngestParser@v0.9.36
-git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.20
+git+https://github.com/adsabs/ADSIngestParser@v0.9.38
+git+https://github.com/adsabs/ADSIngestEnrichment@v0.9.23
 adsputils==1.5.2
 habanero==0.7.4
 namedentities==1.9.4

--- a/run.py
+++ b/run.py
@@ -135,7 +135,7 @@ def get_args():
 
     parser.add_argument('-Z',
                         '--tagged_refs',
-                        dest='tagged_refs'
+                        dest='tagged_refs',
                         action='store_true',
                         default=False,
                         help='Output refs in tagged file (%%Z)')
@@ -147,9 +147,9 @@ def get_args():
 def create_tagged(rec=None, args=None):
     try:
         xlator = translator.Translator(doibib=doi_bibcode_dict)
-        seri = classic_serializer.ClassicSerializer()
+        seri = classic_serializer.ClassicSerializer(tag_refs=args.tagged_refs)
         xlator.translate(data=rec, bibstem=args.bibstem, volume=args.volume, parsedfile=args.parsedfile)
-        output = seri.output(xlator.output, tag_refs=args.tagged_refs)
+        output = seri.output(xlator.output)
         return output
     except Exception as err:
         logger.warning("Export to tagged file failed: %s\t%s" % (err, rec))
@@ -217,7 +217,7 @@ def write_record(record, args):
 def parse_record(rec):
     pdata = rec.get('data', None)
     ptype = rec.get('type', None)
-    filename = rec.get('name', None)
+    filename = rec.get('name', "")
     parser = PARSER_TYPES.get(ptype, None)
     write_file = utils.has_body(pdata)
     parsedrecord = None

--- a/run.py
+++ b/run.py
@@ -231,8 +231,6 @@ def parse_record(rec):
             else:
                 parsedrecord = parser.parse(pdata)
             if parsedrecord:
-                with open("asdf.json","w") as fo:
-                    fo.write("%s\n" % json.dumps(parsedrecord, indent=2, sort_keys=True))
                 if utils.suppress_title(parsedrecord, conf.get("DEPRECATED_TITLES", [])):
                     parsedrecord = None
                     raise Exception("Warning: article matches a suppressed title.")


### PR DESCRIPTION
This update:
- improves handling of references when the translator creates a new bibcode
- adds the `-Z` option to run.py, which writes ref data to `%Z` in tagged output